### PR TITLE
Some bad GIFs have extra blocks beyond the last row, which we should ignore to decode

### DIFF
--- a/std/gif/decode_gif.wuffs
+++ b/std/gif/decode_gif.wuffs
@@ -99,10 +99,11 @@ pub struct decoder? implements base.image_decoder(
 	num_decoded_frame_configs_value : base.u64,
 	num_decoded_frames_value        : base.u64,
 
-	frame_rect_x0 : base.u32,
-	frame_rect_y0 : base.u32,
-	frame_rect_x1 : base.u32,
-	frame_rect_y1 : base.u32,
+	frame_rect_x0   : base.u32,
+	frame_rect_y0   : base.u32,
+	frame_rect_x1   : base.u32,
+	frame_rect_y1   : base.u32,
+	frame_rect_size : base.u64,
 
 	// The dst_etc fields are the output cursor during copy_to_image_buffer.
 	dst_x            : base.u32,
@@ -756,8 +757,9 @@ pri func decoder.decode_id_part0?(src: base.io_reader) {
 	this.frame_rect_x0 = args.src.read_u16le_as_u32?()
 	this.frame_rect_y0 = args.src.read_u16le_as_u32?()
 	this.frame_rect_x1 = args.src.read_u16le_as_u32?()
-	this.frame_rect_x1 ~mod+= this.frame_rect_x0
 	this.frame_rect_y1 = args.src.read_u16le_as_u32?()
+	this.frame_rect_size = (this.frame_rect_x1 as base.u64) * (this.frame_rect_y1 as base.u64)
+	this.frame_rect_x1 ~mod+= this.frame_rect_x0
 	this.frame_rect_y1 ~mod+= this.frame_rect_y0
 
 	this.dst_x = this.frame_rect_x0
@@ -772,6 +774,8 @@ pri func decoder.decode_id_part0?(src: base.io_reader) {
 		this.width = this.width.max(a: this.frame_rect_x1)
 		this.height = this.height.max(a: this.frame_rect_y1)
 	}
+
+	this.lzw.set_unread_data_size!(size: this.frame_rect_size)
 }
 
 pri func decoder.decode_id_part1?(dst: ptr base.pixel_buffer, src: base.io_reader, blend: base.pixel_blend) {

--- a/std/lzw/decode_lzw.wuffs
+++ b/std/lzw/decode_lzw.wuffs
@@ -47,6 +47,9 @@ pub struct decoder? implements base.io_transformer(
 	output_ri : base.u32[..= 8191],
 	output_wi : base.u32[..= 8191],
 
+	// unread data size
+	unread_data_size : base.u64,
+
 	// read_from return value. The read_from method effectively returns a
 	// base.u32 to show how decode should continue after calling write_to. That
 	// value needs to be saved across write_to's possible suspension, so we
@@ -78,6 +81,10 @@ pub func decoder.set_literal_width!(lw: base.u32[..= 8]) {
 
 pub func decoder.workbuf_len() base.range_ii_u64 {
 	return this.util.make_range_ii_u64(min_incl: 0, max_incl: 0)
+}
+
+pub func decoder.set_unread_data_size!(size: base.u64) {
+	this.unread_data_size = args.size
 }
 
 pub func decoder.transform_io?(dst: base.io_writer, src: base.io_reader, workbuf: slice base.u8) {
@@ -296,11 +303,16 @@ pri func decoder.read_from!(src: base.io_reader) {
 				prev_code = code
 			}
 
+		} else if (this.unread_data_size == 0) {
+			// Some bad GIFs have extra blocks beyond the last row, which we should ignore to decode
+			this.read_from_return_value = 0
+			break
 		} else {
 			this.read_from_return_value = 3
 			break
 		}
 
+		this.unread_data_size ~sat-= output_wi as base.u64
 		// Flush the output if it could be too full to contain the entire
 		// decoding of the next code. The longest possible decoding is slightly
 		// less than 4096 and output's length is 8192, so a conservative


### PR DESCRIPTION
resolve issue: https://bugs.chromium.org/p/chromium/issues/detail?id=1270631