### PR TITLE
Improve hello-wuffs-c example

### DIFF
--- a/hello-wuffs-c/README.md
+++ b/hello-wuffs-c/README.md
@@ -20,13 +20,14 @@ pointer. Anyway, here's what the output should look like:
 
 ```
 $ ./run.sh
+--- C Implementation prints ---
 0
 12
 56789
 4294967295
 0
 3197704724
---------
+------ Wuffs Impl Prints ------
 0
 12
 56789

--- a/hello-wuffs-c/main.c
+++ b/hello-wuffs-c/main.c
@@ -16,63 +16,8 @@
 
 #include <inttypes.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-
-#ifndef USE_WUFFS
-uint32_t parse(char* p, size_t n) {
-  uint32_t ret = 0;
-  for (size_t i = 0; (i < n) && p[i]; i++) {
-    ret = (10 * ret) + (p[i] - '0');
-  }
-  return ret;
-}
-#else  // #ifndef USE_WUFFS
-
-// TODO: this 'rough edge' shouldn't be necessary. See
-// https://github.com/google/wuffs/issues/24
-#define WUFFS_CONFIG__MODULE__BASE
-
-#define WUFFS_IMPLEMENTATION
-#include "./parse.c"
-
-uint32_t parse(char* p, size_t n) {
-  wuffs_base__status status;
-  wuffs_demo__parser* parser =
-      (wuffs_demo__parser*)(malloc(sizeof__wuffs_demo__parser()));
-  if (!parser) {
-    printf("malloc failed\n");
-    return 0;
-  }
-
-  status = wuffs_demo__parser__initialize(parser, sizeof__wuffs_demo__parser(),
-                                          WUFFS_VERSION, 0);
-  if (!wuffs_base__status__is_ok(&status)) {
-    printf("initialize: %s\n", wuffs_base__status__message(&status));
-    free(parser);
-    return 0;
-  }
-
-  wuffs_base__io_buffer iobuf;
-  iobuf.data.ptr = (uint8_t*)p;
-  iobuf.data.len = n;
-  iobuf.meta.wi = n;
-  iobuf.meta.ri = 0;
-  iobuf.meta.pos = 0;
-  iobuf.meta.closed = true;
-
-  status = wuffs_demo__parser__parse(parser, &iobuf);
-  if (!wuffs_base__status__is_ok(&status)) {
-    printf("parse: %s\n", wuffs_base__status__message(&status));
-    free(parser);
-    return 0;
-  }
-
-  uint32_t ret = wuffs_demo__parser__value(parser);
-  free(parser);
-  return ret;
-}
-#endif  // #ifndef USE_WUFFS
+uint32_t parse(char *, size_t);
 
 void run(char* p) {
   size_t n = strlen(p) + 1;  // +1 for the trailing NUL that ends a C string.

--- a/hello-wuffs-c/main.c
+++ b/hello-wuffs-c/main.c
@@ -17,6 +17,8 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
+
+// See naive-parse.c and wuffs-parse.c for implementations of this function
 uint32_t parse(char *, size_t);
 
 void run(char* p) {

--- a/hello-wuffs-c/naive-parse.c
+++ b/hello-wuffs-c/naive-parse.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+#include <inttypes.h>
+
+uint32_t parse(char* p, size_t n) {
+  uint32_t ret = 0;
+  for (size_t i = 0; (i < n) && p[i]; i++) {
+    ret = (10 * ret) + (p[i] - '0');
+  }
+  return ret;
+}

--- a/hello-wuffs-c/run.sh
+++ b/hello-wuffs-c/run.sh
@@ -22,12 +22,10 @@ CC=${CC:-gcc}
 # beforehand, to install the wuffs-c compiler.
 wuffs-c gen -package_name demo < parse.wuffs > parse.c
 
-$CC main.c
+echo --- C Implementation prints ---
+$CC main.c naive-parse.c
 ./a.out
 
-echo --------
-
-$CC main.c -DUSE_WUFFS
+echo ------ Wuffs Impl Prints ------
+$CC main.c wuffs-parse.c
 ./a.out
-
-rm a.out parse.c

--- a/hello-wuffs-c/wuffs-parse.c
+++ b/hello-wuffs-c/wuffs-parse.c
@@ -13,9 +13,9 @@ uint32_t parse(char* p, size_t n) {
   // wuffs_demo__parser *parser = wuffs_demo__parser__alloc();
   // and don't run __initialize();
   wuffs_demo__parser parser;
-
   status = wuffs_demo__parser__initialize(&parser, sizeof__wuffs_demo__parser(),
                                           WUFFS_VERSION, 0);
+  // This happens when bad arguments are passed to __initialize()
   if (!wuffs_base__status__is_ok(&status)) {
     printf("initialize: %s\n", wuffs_base__status__message(&status));
     return 0;
@@ -29,6 +29,7 @@ uint32_t parse(char* p, size_t n) {
   iobuf.meta.pos = 0;
   iobuf.meta.closed = true;
 
+  // This happens when wuffs code returns "# Some status"
   status = wuffs_demo__parser__parse(&parser, &iobuf);
   if (!wuffs_base__status__is_ok(&status)) {
     printf("parse: %s\n", wuffs_base__status__message(&status));

--- a/hello-wuffs-c/wuffs-parse.c
+++ b/hello-wuffs-c/wuffs-parse.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+
+// TODO: this 'rough edge' shouldn't be necessary. See
+// https://github.com/google/wuffs/issues/24
+#define WUFFS_CONFIG__MODULE__BASE
+
+#define WUFFS_IMPLEMENTATION
+#include "./parse.c"
+
+uint32_t parse(char* p, size_t n) {
+  wuffs_base__status status;
+  // If you want this on the heap instead, use
+  // wuffs_demo__parser *parser = wuffs_demo__parser__alloc();
+  // and don't run __initialize();
+  wuffs_demo__parser parser;
+
+  status = wuffs_demo__parser__initialize(&parser, sizeof__wuffs_demo__parser(),
+                                          WUFFS_VERSION, 0);
+  if (!wuffs_base__status__is_ok(&status)) {
+    printf("initialize: %s\n", wuffs_base__status__message(&status));
+    return 0;
+  }
+
+  wuffs_base__io_buffer iobuf;
+  iobuf.data.ptr = (uint8_t*)p;
+  iobuf.data.len = n;
+  iobuf.meta.wi = n;
+  iobuf.meta.ri = 0;
+  iobuf.meta.pos = 0;
+  iobuf.meta.closed = true;
+
+  status = wuffs_demo__parser__parse(&parser, &iobuf);
+  if (!wuffs_base__status__is_ok(&status)) {
+    printf("parse: %s\n", wuffs_base__status__message(&status));
+    return 0;
+  }
+
+  uint32_t ret = wuffs_demo__parser__value(&parser);
+  return ret;
+}


### PR DESCRIPTION
Made it more readable by factoring the `#ifdefs` into separate files.

Additionally, removed the needless heap allocation in the `wuffs`-using implementation of `parse`, and added a comment on the seemingly "correct" way to do this if you did want that, which was not what was being used previously.

Added comments about why `wuffs_base__status__is_ok()` might return `false`.