### PR TITLE
Fix Rust PNG benchmark

### DIFF
--- a/script/bench-rust-png/Cargo.toml
+++ b/script/bench-rust-png/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.0.1"
 authors = ["Nigel Tao <nigeltao@golang.org>"]
 
 [dependencies]
-png     = "*"
+png     = "0.17"
 rustc_version_runtime = "*"


### PR DESCRIPTION
The Rust PNG benchmark no longer compiles. This is similar to the issue that was fixed in pull request #68 for the Rust GIF benchmark. A new version of the png crate was published that broke clean builds. I've pinned the version to 0.17, which is the newest, and changed the code to use the new API.

NOTE: Parts of the png crate documentation hasn't been updated to correctly list the new transformation defaults. The documentation for the `normalize_to_color8` method does say that the defaults changed from version 0.16 to 0.17.