### PR TITLE
optimize SDC

### DIFF
--- a/release/c/wuffs-unsupported-snapshot.c
+++ b/release/c/wuffs-unsupported-snapshot.c
@@ -14788,12 +14788,12 @@ wuffs_base__private_implementation__high_prec_dec__to_f64(
     // When Eisel-Lemire fails, fall back to Simple Decimal Conversion. See
     // https://nigeltao.github.io/blog/2020/parse-number-f64-simple.html
     //
-    // Scale by powers of 2 until we're in the range [½ .. 1], which gives us
-    // our exponent (in base-2). First we shift right, possibly a little too
-    // far, ending with a value certainly below 1 and possibly below ½...
+    // Scale by powers of 2 until we're in the range [1 .. 2]. First we shift
+    // right, possibly a little too far, ending with a value certainly below
+    // 10 ...
     const int32_t f64_bias = -1023;
     int32_t exp2 = 0;
-    while (h->decimal_point > 0) {
+    while (h->decimal_point > 1) {
       uint32_t n = (uint32_t)(+h->decimal_point);
       uint32_t shift =
           (n < num_powers)
@@ -14807,20 +14807,13 @@ wuffs_base__private_implementation__high_prec_dec__to_f64(
       }
       exp2 += (int32_t)shift;
     }
-    // ...then we shift left, putting us in [½ .. 1].
-    while (h->decimal_point <= 0) {
+    // ... then we shift left, putting us in [0.1 .. 10].
+    while (h->decimal_point < 0) {
       uint32_t shift;
-      if (h->decimal_point == 0) {
-        if (h->digits[0] >= 5) {
-          break;
-        }
-        shift = (h->digits[0] < 2) ? 2 : 1;
-      } else {
         uint32_t n = (uint32_t)(-h->decimal_point);
         shift = (n < num_powers)
-                    ? powers[n]
+                    ? powers[n] + 1 // shift 1 extra since we're now multiplying
                     : WUFFS_BASE__PRIVATE_IMPLEMENTATION__HPD__SHIFT__MAX_INCL;
-      }
 
       wuffs_base__private_implementation__high_prec_dec__small_lshift(h, shift);
       if (h->decimal_point >
@@ -14830,9 +14823,40 @@ wuffs_base__private_implementation__high_prec_dec__to_f64(
       exp2 -= (int32_t)shift;
     }
 
-    // We're in the range [½ .. 1] but f64 uses [1 .. 2].
-    exp2--;
-
+    // To get into the range [1 .. 2] we need to look at the first 3 digits of
+    // the mantisse to determine the final left shift. If we are already between 1
+    // and 2 then just shift left by 52.
+    uint64_t man = 0;
+    uint32_t i;
+    for (i = 0; i < 3; i++) {
+        man = (10 * man) + ((i < h->num_digits) ? h->digits[i] : 0);
+    }
+    int32_t final_lshift = 52;
+    int32_t additional_shift = 0;
+    if (h->decimal_point == 0) { // value is in [0.1 .. 1]
+        if (man < 125) {
+            additional_shift = -4;
+        } else if (man < 250) {
+            additional_shift = -3;
+        } else if (man < 500) {
+            additional_shift = -2;
+        } else {
+            additional_shift = -1;
+        }
+    } else { // value is in [1 .. 10]
+        if (man < 200) {
+            additional_shift = 0;
+        } else if (man < 400) {
+            additional_shift = 1;
+        } else if (man < 800) {
+            additional_shift = 2;
+        } else {
+            additional_shift = 3;
+        }
+    }
+    exp2 += additional_shift;
+    final_lshift -= additional_shift;
+    
     // The minimum normal exponent is (f64_bias + 1).
     while ((f64_bias + 1) > exp2) {
       uint32_t n = (uint32_t)((f64_bias + 1) - exp2);
@@ -14849,7 +14873,7 @@ wuffs_base__private_implementation__high_prec_dec__to_f64(
     }
 
     // Extract 53 bits for the mantissa (in base-2).
-    wuffs_base__private_implementation__high_prec_dec__small_lshift(h, 53);
+    wuffs_base__private_implementation__high_prec_dec__small_lshift(h, final_lshift);
     uint64_t man2 =
         wuffs_base__private_implementation__high_prec_dec__rounded_integer(h);
 


### PR DESCRIPTION
So you once wrote about SDC:

_It's not the fastest or cleverest algorithm, but a rarely-invoked fallback doesn't have to be, and there is value in simplicity._

I couldn't agree more, so I propose a very small change which makes the code even simpler but at the same moment saves a lot of calls to the 'expensive' `lshift` and `rshift` calls making the algorithm also faster as a bonus.

I do realize that 'simpler' is a bit of a personal judgement, but I think I may have a case because of these arguments:
- focus is now on the range [1 .. 2] which is after all the end goal and not [½ .. 1] (which imho is making things needlessly complicated; in the article you mention that this range is 'slightly easier, computationally, than getting to the [1 .. 2] range' but I don't see why, maybe I'm missing something)
- `lshift` and `rshift` while loops are now identical which makes things simple (well, almost identical except for a small enhancement mentioned below)
- no need for a double nested `if` in the `lshift` while loop
- comparing the first 3 digits (which is also done in other places in the code) is straightforward and the reader can directly see the relationship between the mantissa and the target `exp2` and the final `lshift`
- no need to do an `exp2--` which to a reader might be somewhat unexpected and feels like an exception ('// We're in the range [½ .. 1] but f64 uses [1 .. 2].')
- no need to pass the 'magic' number '53' to the final `lshift`, which is needed because of the 'wrong' range [½ .. 1] in the first place. If the mantissa is already in [1 .. 2] it's now easy to see from the code that the `lshift` is just the default `52`.

### Test results:
I ran the std/json tests with my change and made sure SDC is always used, so I temporarily disabled Eisel-Lemire and the code when the number is exactly representable by a double. The result was that it saved 73 calls to `lshift` and 32 calls to `rshift`.

### About the change itself:
The change makes sure that once the `lshift` and `rshift` loops are done the `decimal_point` is either 0 or 1 (so the value is the range [0.1 .. 10]). It then looks at the digits to calculate the final `lshift`. If the number happens to be already in [1 .. 2] then the final `lshift` is just 52. This calculated shift will be between 56 (for values in the range [0.1 .. 0.125] and 49 (for values in the range [8 .. 10]).

Another very small change is this: the same entry from the powers table is used for the `lshift` and `rshift`. This entry is chosen in such a way that if the value is divided by (2 ** entry) you'll end up in [0.1 .. 2]. And since this is within [0.1 .. 10] it's the ideal candidate for the `rshift`. But the `lshift` does the opposite so with that same entry you will always end up in the range [0.05 .. 1]. Not good. So if you just add 1 to the entry the range will be [0.1 .. 2] again which is exactly within the target range. This simple addition alone will save needless calls to `lshift`.