### PR TITLE
Support prctl in musl libc based systems

### DIFF
--- a/example/bzcat/bzcat.c
+++ b/example/bzcat/bzcat.c
@@ -62,7 +62,9 @@ for a C compiler $CC, such as clang or gcc.
 #include "../../release/c/wuffs-unsupported-snapshot.c"
 
 #if defined(__linux__)
+#ifdef __GLIBC__
 #include <linux/prctl.h>
+#endif
 #include <linux/seccomp.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>

--- a/example/convert-to-nia/convert-to-nia.c
+++ b/example/convert-to-nia/convert-to-nia.c
@@ -80,7 +80,9 @@ https://skia-review.googlesource.com/c/skia/+/290618
 // ----
 
 #if defined(__linux__)
+#ifdef __GLIBC__
 #include <linux/prctl.h>
+#endif
 #include <linux/seccomp.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>

--- a/example/jsonptr/jsonptr.cc
+++ b/example/jsonptr/jsonptr.cc
@@ -141,7 +141,9 @@ for a C++ compiler $CXX, such as clang++ or g++.
 #include "../../release/c/wuffs-unsupported-snapshot.c"
 
 #if defined(__linux__)
+#ifdef __GLIBC__
 #include <linux/prctl.h>
+#endif
 #include <linux/seccomp.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>

--- a/example/zcat/zcat.c
+++ b/example/zcat/zcat.c
@@ -64,7 +64,9 @@ for a C compiler $CC, such as clang or gcc.
 #include "../../release/c/wuffs-unsupported-snapshot.c"
 
 #if defined(__linux__)
+#ifdef __GLIBC__
 #include <linux/prctl.h>
+#endif
 #include <linux/seccomp.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
In musl libc based systems, `<linux/prctl.h>` is automatically pulled by `<sys/prctl.h>` so should not be included.