### PR TITLE
Remove duplicate diagnostic pragmas

### DIFF
--- a/cmd/wuffs-c/release.go
+++ b/cmd/wuffs-c/release.go
@@ -174,9 +174,9 @@ const grPragmaPush = `
 // Wuffs' C code is generated automatically, not hand-written. These warnings'
 // costs outweigh the benefits.
 //
-// The "elif defined(__clang__)" isn't redundant. While vanilla clang defines
+// The "|| defined(__clang__)" isn't redundant. While vanilla clang defines
 // __GNUC__, clang-cl (which mimics MSVC's cl.exe) does not.
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -185,16 +185,6 @@ const grPragmaPush = `
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #if defined(__cplusplus)
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wunreachable-code"
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#if defined(__cplusplus)
-#pragma clang diagnostic ignored "-Wold-style-cast"
 #endif
 #endif
 

--- a/release/c/wuffs-unsupported-snapshot.c
+++ b/release/c/wuffs-unsupported-snapshot.c
@@ -11,9 +11,9 @@
 // Wuffs' C code is generated automatically, not hand-written. These warnings'
 // costs outweigh the benefits.
 //
-// The "elif defined(__clang__)" isn't redundant. While vanilla clang defines
+// The "|| defined(__clang__)" isn't redundant. While vanilla clang defines
 // __GNUC__, clang-cl (which mimics MSVC's cl.exe) does not.
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -22,16 +22,6 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #if defined(__cplusplus)
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wunreachable-code"
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-#if defined(__cplusplus)
-#pragma clang diagnostic ignored "-Wold-style-cast"
 #endif
 #endif
 


### PR DESCRIPTION
Clang has been unconditionally accepting the GCC diagnostic pragmas since before the clang pragmas were introduced in [r71572][1].

This means we don't need to duplicate the pragmas for clang-cl's benefit.

[1]: https://github.com/llvm/llvm-project/commit/b61448d4902f28d286e0b2fcb5ff72aea1b3404b